### PR TITLE
Set urllib useragent string.

### DIFF
--- a/src/breadability/client.py
+++ b/src/breadability/client.py
@@ -13,6 +13,10 @@ from breadability.logconfig import LNODE
 from breadability.logconfig import set_logging_level
 from breadability.readable import Article
 
+class AppURLopener(urllib.FancyURLopener):
+	version = "Mozilla/5.0 (X11; U; Linux i686) Gecko/20100101 Firefox/20.0"
+
+urllib._urlopener = AppURLopener()
 
 LOGLEVEL = 'WARNING'
 


### PR DESCRIPTION
Masquerade as Firefox for maximum compatibility.

Some websites block access to python/urllib based on user-agent.
