### PR TITLE
Make normalize_whitespace faster

### DIFF
--- a/breadability/scoring.py
+++ b/breadability/scoring.py
@@ -85,7 +85,7 @@ def get_link_density(node, node_text=None):
     """
     if node_text is None:
         node_text = node.text_content()
-    node_text = normalize_whitespace(node_text.strip())
+    node_text = normalize_whitespace(node_text)
 
     text_length = len(node_text)
     if text_length == 0:
@@ -101,7 +101,7 @@ def get_link_density(node, node_text=None):
 
 
 def _get_normalized_text_length(node):
-    return len(normalize_whitespace(node.text_content().strip()))
+    return len(normalize_whitespace(node.text_content()))
 
 
 def get_class_weight(node):

--- a/breadability/utils.py
+++ b/breadability/utils.py
@@ -18,9 +18,6 @@ except ImportError:
             pass
 
 
-MULTIPLE_WHITESPACE_PATTERN = re.compile(r"\s+", re.UNICODE)
-
-
 def is_blank(text):
     """
     Returns ``True`` if string contains only whitespace characters
@@ -36,19 +33,8 @@ def shrink_text(text):
 def normalize_whitespace(text):
     """
     Translates multiple whitespace into single space character.
-    If there is at least one new line character chunk is replaced
-    by single LF (Unix new line) character.
     """
-    return MULTIPLE_WHITESPACE_PATTERN.sub(_replace_whitespace, text)
-
-
-def _replace_whitespace(match):
-    text = match.group()
-
-    if "\n" in text or "\r" in text:
-        return "\n"
-    else:
-        return " "
+    return ' '.join(text.split())
 
 
 def cached_property(getter):

--- a/breadability/utils.py
+++ b/breadability/utils.py
@@ -26,15 +26,14 @@ def is_blank(text):
     return not text or text.isspace()
 
 
-def shrink_text(text):
-    return normalize_whitespace(text.strip())
-
-
 def normalize_whitespace(text):
     """
     Translates multiple whitespace into single space character.
     """
     return ' '.join(text.split())
+
+
+shrink_text = normalize_whitespace
 
 
 def cached_property(getter):


### PR DESCRIPTION
This had *significant* consequences on a program of mine.

Before:
```
real	0m5.776s
user	0m4.150s
sys	0m0.077s
```

After:
```
real	0m4.261s
user	0m4.130s
sys	0m0.073s
```
(That's more than a second difference!)

(breadability is called on ± 30 pages during my script execution)

This drops the distinction between \n and whitespaces, but from what I've understood, this distinction is actually not used in the code after.