### PR TITLE
Change docopt to the maitained one

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-docopt>=0.6.1,<0.7
+docopt-ng>=0.6.1
 chardet
 lxml
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(join(CURRENT_DIRECTORY, "README.rst")) as readme:
 
 
 install_requires = [
-    "docopt>=0.6.1,<0.7",
+    "docopt-ng>=0.6.1",
     "chardet",
     "lxml>=2.0",
 ]


### PR DESCRIPTION
I found that the `docopt `of this repo was no longer maintained and cause some issues here
https://github.com/lss233/chatgpt-mirai-qq-bot/pull/62#issuecomment-1431771524. 

Details can be found here 
https://github.com/docopt/docopt/issues/502. 

Therefore, I suggest the use of https://github.com/jazzband/docopt-ng to replace docopt. 