### PR TITLE
Add support for "lxml[html_clean]" v5.2 module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 docopt>=0.6.1,<0.7
 chardet
-lxml
+lxml[html_clean]
 
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open(join(CURRENT_DIRECTORY, "README.rst")) as readme:
 install_requires = [
     "docopt>=0.6.1,<0.7",
     "chardet",
-    "lxml>=2.0",
+    "lxml[html_clean]>=2.0",
 ]
 tests_require = [
     "pytest",


### PR DESCRIPTION
The module was removed in v5.2 and need to be explicitly installed as sub-dependency.