### PR TITLE
Remove pkg_resources version lookup

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,5 +1,3 @@
-# -*- coding: utf8 -*-
-
 from __future__ import (
     absolute_import,
     division,
@@ -7,4 +5,8 @@ from __future__ import (
     unicode_literals
 )
 
-__version__ = "0.1.20"
+import breadability
+
+
+def test_version():
+    assert breadability.__version__ == "0.1.20"


### PR DESCRIPTION
## Summary
- Remove the import-time `pkg_resources` lookup from `breadability.__version__`.
- Keep the package version available without adding a new runtime dependency, preserving the existing old-Python compatibility surface.
- Add a small regression test for the exposed package version.

Fixes #39

## Validation
- `git diff --check HEAD~1..HEAD`
- `rg -n pkg_resources|get_distribution|DistributionNotFound|resource_filename|load_entry_point breadability tests setup.py requirements.txt` (no matches)
- Not run locally: test suite